### PR TITLE
Upgrade for OJS 3.3

### DIFF
--- a/locale/en_US/locale.po
+++ b/locale/en_US/locale.po
@@ -1,0 +1,18 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2022-02-01T09:15:02-05:00\n"
+"PO-Revision-Date: 2022-02-01T09:15:02-05:00\n"
+"Language: \n"
+
+msgid "plugins.generic.sitesearch.displayName"
+msgstr "Sitesearch Plugin"
+
+msgid "plugins.generic.sitesearch.description"
+msgstr "Overrides the public search functionality to act at the site level instead of within the context."

--- a/version.xml
+++ b/version.xml
@@ -12,8 +12,8 @@
 <version>
 	<application>sitesearch</application>
 	<type>plugins.generic</type>
-	<release>1.0.0.0</release>
-	<date>2020-02-17</date>
+	<release>1.1.0.0</release>
+	<date>2022-04-22</date>
 	<lazy-load>1</lazy-load>
 	<class>SitesearchPlugin</class>
 </version>


### PR DESCRIPTION
This one tested fine with the dual-journal JWSR test site, so I've upgraded the plugin version number and added the new .po locale file for 3.3.